### PR TITLE
Package management

### DIFF
--- a/app/controllers/spree/admin/packages_controller.rb
+++ b/app/controllers/spree/admin/packages_controller.rb
@@ -17,7 +17,10 @@ module Spree
       end
 
       def permitted_resource_attributes
-        [:depth, :height, :name, :package_type, :packing_material, :width]
+        [
+          :depth, :description, :height, :name, :package_type,
+          :packing_material, :width
+        ]
       end
     end
   end

--- a/app/controllers/spree/admin/packages_controller.rb
+++ b/app/controllers/spree/admin/packages_controller.rb
@@ -1,0 +1,24 @@
+module Spree
+  module Admin
+    class PackagesController < ResourceController
+      helper "spree/admin/packages"
+
+      def index
+        per_page = params[:per_page] || Kaminari.config.default_per_page
+
+        @packages = Spree::Package.page(params[:page])
+                                  .per(per_page)
+      end
+
+      protected
+
+      def permitted_resource_params
+        params.require(:package).permit(permitted_resource_attributes)
+      end
+
+      def permitted_resource_attributes
+        [:depth, :height, :name, :package_type, :packing_material, :width]
+      end
+    end
+  end
+end

--- a/app/helpers/spree/admin/packages_helper.rb
+++ b/app/helpers/spree/admin/packages_helper.rb
@@ -1,0 +1,6 @@
+module Spree
+  module Admin
+    module PackagesHelper
+    end
+  end
+end

--- a/app/models/spree/package.rb
+++ b/app/models/spree/package.rb
@@ -1,5 +1,9 @@
 module Spree
   class Package < ActiveRecord::Base
+    acts_as_paranoid
+
+    after_destroy :column_reset
+
     validates :depth, numericality: { greater_than: 0 }
     validates :height, numericality: { greater_than: 0 }
     validates :name, presence: true, uniqueness: true
@@ -8,5 +12,11 @@ module Spree
     validates :width, numericality: { greater_than: 0 }
 
     default_scope { order(name: :asc) }
+
+    protected
+
+    def column_reset
+      update_attributes(name: "#{Time.current.to_i}_#{name}")
+    end
   end
 end

--- a/app/models/spree/package.rb
+++ b/app/models/spree/package.rb
@@ -1,0 +1,12 @@
+module Spree
+  class Package < ActiveRecord::Base
+    validates :depth, numericality: { greater_than: 0 }
+    validates :height, numericality: { greater_than: 0 }
+    validates :name, presence: true, uniqueness: true
+    validates :package_type, presence: true,
+                             inclusion: { in: SpreePackages::TYPES }
+    validates :width, numericality: { greater_than: 0 }
+
+    default_scope { order(name: :asc) }
+  end
+end

--- a/app/overrides/spree/admin/shared/_configuration_menu/add_packages_to_configureation_menu.html.erb.deface
+++ b/app/overrides/spree/admin/shared/_configuration_menu/add_packages_to_configureation_menu.html.erb.deface
@@ -1,0 +1,3 @@
+<!-- insert_bottom '[data-hook="admin_configurations_sidebar_menu"], #admin_configurations_sidebar_menu[data-hook]' -->
+
+<%= configurations_sidebar_menu_item Spree.t("packages.sidebar"), admin_packages_path %>

--- a/app/views/spree/admin/packages/_form.html.erb
+++ b/app/views/spree/admin/packages/_form.html.erb
@@ -1,0 +1,58 @@
+<div data-hook="admin_package_form" class="row">
+  <div class="sixteen">
+    <%= f.field_container :name do %>
+      <%= f.label :name, Spree.t("packages.label.name") %> <span class="required">*</span>
+      <%= f.text_field :name, class: "fullwidth" %>
+      <%= f.error_message_on :name %>
+    <% end %>
+  </div>
+
+  <div class="sixteen">
+    <%= f.field_container :description do %>
+      <%= f.label :description, Spree.t("packages.label.description") %>
+      <%= f.text_area :description, class: "fullwidth" %>
+      <%= f.error_message_on :description %>
+    <% end %>
+  </div>
+
+  <div class="alpha eight columns">
+    <%= f.field_container :package_type do %>
+      <%= f.label :package_type, Spree.t("packages.label.package_type") %>
+      <%= f.select :package_type, package_type_options, { selected: f.object.package_type }, { class: "select2 fullwidth" } %>
+      <%= f.error_message_on :package_type %>
+    <% end %>
+  </div>
+
+  <div class="eight columns omega">
+    <%= f.field_container :height do %>
+      <%= f.label :height, Spree.t("packages.label.height") %> <span class="required">*</span>
+      <%= f.text_field :height, class: "fullwidth" %>
+      <%= f.error_message_on :height %>
+    <% end %>
+  </div>
+
+  <div class="alpha eight columns">
+    <%= f.field_container :width do %>
+      <%= f.label :width, Spree.t("packages.label.width") %> <span class="required">*</span>
+      <%= f.text_field :width, class: "fullwidth" %>
+      <%= f.error_message_on :width %>
+    <% end %>
+  </div>
+
+  <div class="eight columns omega">
+    <%= f.field_container :depth do %>
+      <%= f.label :depth, Spree.t("packages.label.depth") %> <span class="required">*</span>
+      <%= f.text_field :depth, class: "fullwidth" %>
+      <%= f.error_message_on :depth %>
+    <% end %>
+  </div>
+
+  <div class="alpha eight columns">
+    <%= f.field_container :packing_material do %>
+      <%= f.label :packing_material do %>
+        <%= f.check_box :packing_material %>
+        <%= Spree.t("packages.label.packing_material") %>
+      <% end %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/spree/admin/packages/_form.html.erb
+++ b/app/views/spree/admin/packages/_form.html.erb
@@ -1,5 +1,5 @@
 <div data-hook="admin_package_form" class="row">
-  <div class="sixteen">
+  <div class="twelve">
     <%= f.field_container :name do %>
       <%= f.label :name, Spree.t("packages.label.name") %> <span class="required">*</span>
       <%= f.text_field :name, class: "fullwidth" %>
@@ -7,7 +7,7 @@
     <% end %>
   </div>
 
-  <div class="sixteen">
+  <div class="twelve">
     <%= f.field_container :description do %>
       <%= f.label :description, Spree.t("packages.label.description") %>
       <%= f.text_area :description, class: "fullwidth" %>
@@ -15,7 +15,7 @@
     <% end %>
   </div>
 
-  <div class="alpha eight columns">
+  <div class="alpha six columns">
     <%= f.field_container :package_type do %>
       <%= f.label :package_type, Spree.t("packages.label.package_type") %>
       <%= f.select :package_type, package_type_options, { selected: f.object.package_type }, { class: "select2 fullwidth" } %>
@@ -23,7 +23,7 @@
     <% end %>
   </div>
 
-  <div class="eight columns omega">
+  <div class="six columns omega">
     <%= f.field_container :height do %>
       <%= f.label :height, Spree.t("packages.label.height") %> <span class="required">*</span>
       <%= f.text_field :height, class: "fullwidth" %>
@@ -31,7 +31,7 @@
     <% end %>
   </div>
 
-  <div class="alpha eight columns">
+  <div class="alpha six columns">
     <%= f.field_container :width do %>
       <%= f.label :width, Spree.t("packages.label.width") %> <span class="required">*</span>
       <%= f.text_field :width, class: "fullwidth" %>
@@ -39,7 +39,7 @@
     <% end %>
   </div>
 
-  <div class="eight columns omega">
+  <div class="six columns omega">
     <%= f.field_container :depth do %>
       <%= f.label :depth, Spree.t("packages.label.depth") %> <span class="required">*</span>
       <%= f.text_field :depth, class: "fullwidth" %>
@@ -47,7 +47,7 @@
     <% end %>
   </div>
 
-  <div class="alpha eight columns">
+  <div class="alpha six columns">
     <%= f.field_container :packing_material do %>
       <%= f.label :packing_material do %>
         <%= f.check_box :packing_material %>

--- a/app/views/spree/admin/packages/edit.html.erb
+++ b/app/views/spree/admin/packages/edit.html.erb
@@ -8,6 +8,9 @@
   <li>
     <%= button_link_to Spree.t("packages.back_to_packages_list"), spree.admin_packages_path, icon: "arrow-left" %>
   </li>
+  <li>
+    <%= button_link_to Spree.t("packages.new_package"), spree.new_admin_package_path, icon: "plus" %>
+  </li>
 <% end %>
 
 <div data-hook="admin_package_edit_form_header">

--- a/app/views/spree/admin/packages/edit.html.erb
+++ b/app/views/spree/admin/packages/edit.html.erb
@@ -1,0 +1,23 @@
+<% content_for :page_title do %>
+  <%= Spree.t("packages.edit_package") %>
+<% end %>
+
+<% content_for :page_actions do %>
+  <li>
+    <%= button_link_to Spree.t("packages.back_to_packages_list"), spree.admin_packages_path, icon: "arrow-left" %>
+  </li>
+<% end %>
+
+<div data-hook="admin_package_edit_form_header">
+  <%= render partial: "spree/shared/error_messages", locals: { target: @package } %>
+</div>
+
+<div data-hook="admin_package_edit_form">
+  <%= form_for [:admin, @package], url: admin_packages_url, method: :post do |f| %>
+    <%= render partial: "form", locals: { f: f } %>
+
+    <div data-hook="admin_package_new_form_buttons">
+      <%= render partial: "spree/admin/shared/edit_resource_links" %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/spree/admin/packages/edit.html.erb
+++ b/app/views/spree/admin/packages/edit.html.erb
@@ -1,3 +1,5 @@
+<%= render partial: "spree/admin/shared/configuration_menu" %>
+
 <% content_for :page_title do %>
   <%= Spree.t("packages.edit_package") %>
 <% end %>

--- a/app/views/spree/admin/packages/index.html.erb
+++ b/app/views/spree/admin/packages/index.html.erb
@@ -1,0 +1,47 @@
+<% content_for :page_title do %>
+  <%= Spree.t("packages.packages") %>
+<% end %>
+
+<% content_for :page_actions do %>
+  <li>
+    <%= button_link_to Spree.t("packages.new_package"), new_admin_package_path, icon: "plus", id: "admin_new_package_link" %>
+  </li>
+<% end %>
+
+<% if @packages.any? %>
+  <%= paginate @packages %>
+
+  <table class="index" id="listing_packages" data-hook>
+    <colgroup>
+      <col style="width: 70%">
+      <col style="width: 20%">
+      <col style="width: 10%">
+    </colgroup>
+
+    <thead>
+      <tr data-hook="admin_packages_index_headers">
+        <th><%= Spree.t("packages.header.name") %></th>
+        <th><%= Spree.t("packages.header.package_type") %></th>
+        <th data-hook="admin_packages_index_header_actions" class="actions"></th>
+      </tr>
+    </thead>
+
+    <tbody>
+      <% @packages.each do |package|%>
+        <tr id="<%= spree_dom_id package %>" data-hook="admin_packages_index_rows" class="<%= cycle('odd', 'even')%>">
+          <td><%=link_to package.name, edit_admin_package_path(package) %></td>
+          <td><%= Spree.t("packages.type.#{package.package_type}") %></td>
+          <td data-hook="admin_users_index_row_actions" class="actions">
+            <%= link_to_edit package, no_text: true %>
+            <%= link_to_delete package, no_text: true %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% else %>
+  <div class="alpha twelve columns no-objects-found">
+    <%= Spree.t(:no_resource_found, resource: I18n.t(:other, scope: "activerecord.models.spree/package")) %>,
+    <%= link_to Spree.t(:add_one), spree.new_admin_package_path %>!
+  </div>
+<% end %>

--- a/app/views/spree/admin/packages/index.html.erb
+++ b/app/views/spree/admin/packages/index.html.erb
@@ -1,3 +1,5 @@
+<%= render partial: "spree/admin/shared/configuration_menu" %>
+
 <% content_for :page_title do %>
   <%= Spree.t("packages.packages") %>
 <% end %>
@@ -13,9 +15,9 @@
 
   <table class="index" id="listing_packages" data-hook>
     <colgroup>
-      <col style="width: 70%">
+      <col style="width: 65%">
       <col style="width: 20%">
-      <col style="width: 10%">
+      <col style="width: 15%">
     </colgroup>
 
     <thead>

--- a/app/views/spree/admin/packages/new.html.erb
+++ b/app/views/spree/admin/packages/new.html.erb
@@ -1,0 +1,23 @@
+<% content_for :page_title do %>
+  <%= Spree.t("packages.new_package") %>
+<% end %>
+
+<% content_for :page_actions do %>
+  <li>
+    <%= button_link_to Spree.t("packages.back_to_packages_list"), spree.admin_packages_path, icon: "arrow-left" %>
+  </li>
+<% end %>
+
+<div data-hook="admin_package_new_form_header">
+  <%= render partial: "spree/shared/error_messages", locals: { target: @package } %>
+</div>
+
+<div data-hook="admin_package_new_form">
+  <%= form_for [:admin, @package], url: admin_packages_url, method: :post do |f| %>
+    <%= render partial: "form", locals: { f: f } %>
+
+    <div data-hook="admin_package_new_form_buttons">
+      <%= render partial: "spree/admin/shared/new_resource_links" %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/spree/admin/packages/new.html.erb
+++ b/app/views/spree/admin/packages/new.html.erb
@@ -1,3 +1,5 @@
+<%= render partial: "spree/admin/shared/configuration_menu" %>
+
 <% content_for :page_title do %>
   <%= Spree.t("packages.new_package") %>
 <% end %>

--- a/config/locales/active_record.en.yml
+++ b/config/locales/active_record.en.yml
@@ -1,0 +1,16 @@
+en:
+  activerecord:
+    models:
+      spree/package:
+        one: Packaging Container
+        other: Packaging Containers
+
+  attributes:
+    spree/package:
+      depth: Depth
+      description: Description
+      height: Height
+      name: Name
+      package_type: Package Type
+      packing_material: Packing Material
+      width: Width

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,10 +1,26 @@
 en:
   spree:
     packages:
+      back_to_packages_list: Back to Packaging Container List
+      edit_package: Edit Packaging Container
+      header:
+        name: Name
+        package_type: Package Type
+      label:
+        depth: Depth
+        description: Description
+        height: Height
+        name: Name
+        package_type: Package Type
+        packing_material: Requires Packing Material
+        width: Width
+      new_package: New Packaging Container
+      packages: Packaging Containers
+      sidebar: Packaging Containers
       type:
+        custom: Unique or custom packaging
         poly: Box or poly-mailer
         tube: Poster tube
         letter: Letter or flat mailer
-        custom: Unique or custom packaging
 
     package_type: Package Type

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,2 +1,5 @@
 Spree::Core::Engine.routes.draw do
+  namespace :admin do
+    resources :packages, except: [:show]
+  end
 end

--- a/db/migrate/20160401171052_create_packages.rb
+++ b/db/migrate/20160401171052_create_packages.rb
@@ -1,0 +1,17 @@
+class CreatePackages < ActiveRecord::Migration
+  def change
+    create_table :spree_packages do |t|
+      t.string :name
+      t.string :description
+      t.string :package_type, default: "poly"
+      t.decimal :height, precision: 8, scale: 2
+      t.decimal :width, precision: 8, scale: 2
+      t.decimal :depth, precision: 8, scale: 2
+      t.boolean :packing_material, default: false
+
+      t.timestamps
+    end
+
+    add_index :spree_packages, :name, unique: true
+  end
+end

--- a/db/migrate/20160401234147_add_deleted_at_to_spree_packages.rb
+++ b/db/migrate/20160401234147_add_deleted_at_to_spree_packages.rb
@@ -1,0 +1,7 @@
+class AddDeletedAtToSpreePackages < ActiveRecord::Migration
+  def change
+    add_column :spree_packages, :deleted_at, :datetime
+
+    add_index :spree_packages, :deleted_at
+  end
+end

--- a/lib/spree_packages/factories.rb
+++ b/lib/spree_packages/factories.rb
@@ -4,3 +4,26 @@ FactoryGirl.modify do
     package_type "poly"
   end
 end
+
+# Packages
+FactoryGirl.define do
+  factory :package, class: Spree::Package do
+    sequence(:name) { |n| "Package Container #{n}" }
+    package_type "poly"
+    height 0.1
+    width 0.1
+    depth 0.1
+
+    trait :letter do
+      package_type "letter"
+    end
+
+    trait :tube do
+      package_type "tube"
+    end
+
+    trait :packing_material do
+      packing_material true
+    end
+  end
+end

--- a/spec/controllers/spree/admin/packages_controller_spec.rb
+++ b/spec/controllers/spree/admin/packages_controller_spec.rb
@@ -50,4 +50,20 @@ RSpec.describe Spree::Admin::PackagesController, type: :controller do
       end
     end
   end
+
+  describe "DELETE #destroy" do
+    let(:package) { create(:package) }
+
+    it "deletes the user" do
+      now = Time.now.to_i
+
+      destroy_result = spree_delete :destroy, id: package
+
+      package.reload
+
+      expect{ destroy_result }.to change(Spree::Package, :count).by(0)
+      expect(package.deleted_at).not_to be_nil
+      expect(package.name).to have_content now
+    end
+  end
 end

--- a/spec/controllers/spree/admin/packages_controller_spec.rb
+++ b/spec/controllers/spree/admin/packages_controller_spec.rb
@@ -1,0 +1,53 @@
+require "spec_helper"
+
+RSpec.describe Spree::Admin::PackagesController, type: :controller do
+  stub_authorization!
+
+  describe "GET #index" do
+    it "assigns all packages as @packages" do
+      packages = create_list(:package, 5)
+
+      spree_get :index
+
+      expect(assigns(:packages)).to eq(packages)
+    end
+  end
+
+  describe "POST #create" do
+    context "with valid params" do
+      let(:params) do
+        {
+          name: "New Package",
+          package_type: "poly",
+          height: 0.1,
+          width: 0.1,
+          depth: 0.1
+        }
+      end
+
+      it "creates a new package" do
+        expect do
+          spree_post :create, package: params
+        end.to change(Spree::Package, :count).by(1)
+      end
+    end
+
+    context "with invalid params" do
+      let(:params) do
+        { name: nil }
+      end
+
+      it "assigns a newly created but unsaved package as @package" do
+        spree_post :create, package: params
+
+        expect(assigns(:package)).to be_a_new(Spree::Package)
+      end
+
+      it "re-renders the 'new' template" do
+        spree_post :create, package: params
+
+        expect(response).to render_template(:new)
+      end
+    end
+  end
+end

--- a/spec/features/admin/buttons_spec.rb
+++ b/spec/features/admin/buttons_spec.rb
@@ -1,0 +1,38 @@
+require "spec_helper"
+
+RSpec.feature "Action button in title bar" do
+  stub_authorization!
+
+  let(:index_path) { spree.admin_packages_path }
+  let(:new_path) { spree.new_admin_package_path }
+  let(:new_element) { "[data-hook='toolbar'] a[href='#{new_path}']" }
+  let(:index_element) { "[data-hook='toolbar'] a[href='#{index_path}']" }
+
+  describe "package listing" do
+    before { visit index_path }
+
+    it "links to create package" do
+      expect(page).to have_css(new_element)
+    end
+  end
+
+  describe "new package" do
+    before { visit new_path }
+
+    it "links to package listing" do
+      expect(page).to have_css(index_element)
+    end
+  end
+
+  describe "package edit" do
+    before { visit spree.edit_admin_package_path(create(:package)) }
+
+    it "links to package listing" do
+      expect(page).to have_css(index_element)
+    end
+
+    it "links to package create" do
+      expect(page).to have_css(new_element)
+    end
+  end
+end

--- a/spec/features/admin/sidebar_spec.rb
+++ b/spec/features/admin/sidebar_spec.rb
@@ -1,0 +1,22 @@
+require "spec_helper"
+
+RSpec.feature "Sidebar link" do
+  stub_authorization!
+
+  let(:general_path) { spree.edit_admin_general_settings_path }
+  let(:packages_path) { spree.admin_packages_path }
+  let(:element) { ".sidebar li:last-child.active" }
+
+  it "shows in the sidebar" do
+    visit general_path
+
+    expect(page).to have_link(Spree.t("packages.sidebar"), href: packages_path)
+    expect(page).to_not have_css(element)
+  end
+
+  it "shows highlighted in the sidebar" do
+    visit packages_path
+
+    expect(page).to have_css(element)
+  end
+end

--- a/spec/helpers/spree/admin/packages_helper_spec.rb
+++ b/spec/helpers/spree/admin/packages_helper_spec.rb
@@ -1,0 +1,4 @@
+require "spec_helper"
+
+RSpec.describe Spree::Admin::PackagesHelper, type: :helper do
+end

--- a/spec/models/spree/package_spec.rb
+++ b/spec/models/spree/package_spec.rb
@@ -1,0 +1,31 @@
+require "spec_helper"
+
+RSpec.describe Spree::Package, type: :model do
+  context "validation" do
+    let(:package) { build(:package) }
+
+    it "require unique `name`" do
+      expect(package).to validate_uniqueness_of :name
+    end
+
+    it "allows valid package_type values" do
+      SpreePackages::TYPES.each do |value|
+        expect(package).to allow_value(value).for(:package_type)
+      end
+    end
+
+    it "rejects invalid package_type values" do
+      expect(package).not_to allow_value("fake").for(:package_type)
+    end
+
+    %w(depth height width).each do |dimension|
+      it "requires valid values for `#{dimension}`" do
+        expect(package).to allow_value(1).for(:"#{dimension}")
+      end
+
+      it "does not allow invalid values for `#{dimension}`" do
+        expect(package).not_to allow_value(0).for(:"#{dimension}")
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Summary

Add the ability to manage the different packaging containers.

# What's New

- Manage packages (CRUD)
- `destroy` uses `acts_as_paranoid` so there is always a record of the packaging container used
  - `name` must be unique so reset the value so it can be used again
- Add `Packaging Containers` link to sidebar